### PR TITLE
Send auth mechanism as an argument when running unpub

### DIFF
--- a/unpub/bin/unpub.dart
+++ b/unpub/bin/unpub.dart
@@ -22,6 +22,7 @@ void main(List<String> args) async {
   var port = int.parse(results['port'] as String);
   var dbUri = results['database'] as String;
   var uploader = results['uploader'] as String?;
+  var authMechanism = results['auth_mechanism'] as String?;
 
   if (results.rest.isNotEmpty) {
     print('Got unexpected arguments: "${results.rest.join(' ')}".\n\nUsage:\n');
@@ -31,6 +32,7 @@ void main(List<String> args) async {
 
   var mongoStore = unpub.MongoStore();
   await mongoStore.create(dbUri);
+  mongoStore.db.selectAuthenticationMechanism(authMechanism ?? 'SCRAM-SHA-256');
   await mongoStore.db.open();
 
   var baseDir = path.absolute('unpub-packages');

--- a/unpub/example/main.dart
+++ b/unpub/example/main.dart
@@ -3,9 +3,11 @@ import 'package:unpub/unpub.dart' as unpub;
 
 main(List<String> args) async {
   const dbUri = 'mongodb://localhost:27017/dart_pub';
+  const authenticationMechanism = 'SCRAM-SHA-1';
 
   var metaStore = unpub.MongoStore();
   await metaStore.create(dbUri);
+  metaStore.db.selectAuthenticationMechanism(authenticationMechanism);
   await metaStore.db.open();
 
   final app = unpub.App(

--- a/unpub/example/main.dart
+++ b/unpub/example/main.dart
@@ -3,11 +3,9 @@ import 'package:unpub/unpub.dart' as unpub;
 
 main(List<String> args) async {
   const dbUri = 'mongodb://localhost:27017/dart_pub';
-  const authenticationMechanism = 'SCRAM-SHA-1';
 
   var metaStore = unpub.MongoStore();
   await metaStore.create(dbUri);
-  metaStore.db.selectAuthenticationMechanism(authenticationMechanism);
   await metaStore.db.open();
 
   final app = unpub.App(


### PR DESCRIPTION
Unpub was forcing our connection to happen with the authentication mechanism SCRAM-SHA-256.
This PR makes it so we can pass another authentication mechanism as an argument when running Unpub